### PR TITLE
Support Custom Stopwords

### DIFF
--- a/RediSearchClient.Tests/Indexes/RediSearchIndexTests.cs
+++ b/RediSearchClient.Tests/Indexes/RediSearchIndexTests.cs
@@ -25,6 +25,53 @@ namespace RediSearchClient.Tests.Indexes
 
                 Assert.NotNull(index);
             }
+
+            [Fact]
+            public void CanBeCreatedWithNoStopwords()
+            {
+                var index = RediSearchIndex
+                    .OnHash()
+                    .WithNoStopwords()
+                    .WithSchema(x => x.Text("Testing"))
+                    .Build();
+
+                Assert.NotNull(index);
+            }
+
+            [Fact]
+            public void CanBeCreatedWithCustomStopwordsList()
+            {
+                var index = RediSearchIndex
+                    .OnHash()
+                    .WithStopwords(new []{"if", "or", "else"})
+                    .WithSchema(x => x.Text("Testing"))
+                    .Build();
+
+                Assert.NotNull(index);
+            }
+            [Fact]
+            public void CanBeCreatedWithCustomStopwordsParam()
+            {
+                var index = RediSearchIndex
+                    .OnHash()
+                    .WithStopwords("if", "or", "else")
+                    .WithSchema(x => x.Text("Testing"))
+                    .Build();
+
+                Assert.NotNull(index);
+            }
+
+            [Fact]
+            public void CanBeCreatedWithCustomStopword()
+            {
+                var index = RediSearchIndex
+                    .OnHash()
+                    .WithStopwords("if")
+                    .WithSchema(x => x.Text("Testing"))
+                    .Build();
+
+                Assert.NotNull(index);
+            }
         }
     }
 }

--- a/RediSearchClient/IndexDefinition.cs
+++ b/RediSearchClient/IndexDefinition.cs
@@ -23,6 +23,12 @@ namespace RediSearchClient
         public string[] Prefixes { get; private set; }
 
         /// <summary>
+        /// Custom set of Stopwords
+        /// </summary>
+        /// <value></value>
+        public string[] Stopwords { get; private set; }
+
+        /// <summary>
         /// The filter expression applied to the index during creation. 
         /// </summary>
         /// <value></value>
@@ -83,6 +89,10 @@ namespace RediSearchClient
                         break;
                     case "payload_field":
                         result.PayloadField = (string)redisResults[++i];
+                        break;
+                    case "stopwords_list":
+                        var stopwords = (RedisResult[])redisResults[++i];
+                        result.Stopwords = stopwords.Select(x => x.ToString()).ToArray();
                         break;
                     default:
                         ++i;


### PR DESCRIPTION
This PR is in reference to my issue #18. @tombatron let me know if you have concerns, this is just a first stab between other things.

If unspecified upon index creation, the RediSearch uses the default list of stopwords, if a user invokes `WithNoStopwords()` then we translate that to `STOPWORDS 0` , which means there are no stopwords. Otherwise, any amount of strings may be passed which would allow for a custom list of stopwords.