### PR TITLE
Null check on RedisResult in SuggestionResult.cs

### DIFF
--- a/RediSearchClient.Tests/SpellCheckResultCollectionTests.cs
+++ b/RediSearchClient.Tests/SpellCheckResultCollectionTests.cs
@@ -1,3 +1,4 @@
+using StackExchange.Redis;
 using Xunit;
 
 namespace RediSearchClient.Tests
@@ -37,6 +38,15 @@ namespace RediSearchClient.Tests
             }
 
             Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void Create_ReturnsEmptyArray_WithNullInput()
+        {
+            RedisResult redisResult = RedisResult.Create(new RedisValue(null));
+            var res = SpellCheckResult.CreateArray(redisResult);
+
+            Assert.Empty(res);
         }
 
         [Fact]

--- a/RediSearchClient.Tests/SuggestionResultCollectionTests.cs
+++ b/RediSearchClient.Tests/SuggestionResultCollectionTests.cs
@@ -1,0 +1,17 @@
+using StackExchange.Redis;
+using Xunit;
+
+namespace RediSearchClient.Tests;
+
+public class SuggestionResultCollectionTests
+{
+    [Fact]
+    public void Create_ReturnsEmptyArray_WithNullInput()
+    {
+        RedisResult redisResult = RedisResult.Create(new RedisValue(null));
+        var res = SuggestionResult.CreateArray(redisResult, true, true);
+
+        Assert.Empty(res);
+    }
+
+}

--- a/RediSearchClient/SpellCheckResult.cs
+++ b/RediSearchClient/SpellCheckResult.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System;
 using StackExchange.Redis;
 
 namespace RediSearchClient
@@ -69,6 +69,10 @@ namespace RediSearchClient
 
         internal static SpellCheckResult[] CreateArray(RedisResult redisResult)
         {
+            if (redisResult.IsNull)
+            {
+                return Array.Empty<SpellCheckResult>();
+            }
             var redisResultArray = (RedisResult[])redisResult;
 
             var results = new SpellCheckResult[redisResultArray.Length];

--- a/RediSearchClient/SuggestionResult.cs
+++ b/RediSearchClient/SuggestionResult.cs
@@ -1,4 +1,5 @@
 using StackExchange.Redis;
+using System;
 
 namespace RediSearchClient
 {
@@ -29,7 +30,7 @@ namespace RediSearchClient
         {
             if (redisResult.IsNull)
             {
-                return new SuggestionResult[0];
+                return Array.Empty<SuggestionResult>();
             }
             var redisResultArray = (RedisResult[])redisResult;
 

--- a/RediSearchClient/SuggestionResult.cs
+++ b/RediSearchClient/SuggestionResult.cs
@@ -27,6 +27,10 @@ namespace RediSearchClient
 
         internal static SuggestionResult[] CreateArray(RedisResult redisResult, bool withScores, bool withPayloads)
         {
+            if (redisResult.IsNull)
+            {
+                return new SuggestionResult[0];
+            }
             var redisResultArray = (RedisResult[])redisResult;
 
             var suggestionComponentLength = 1 + (withScores ? 1 : 0) + (withPayloads ? 1 : 0);


### PR DESCRIPTION
During the holiday break we had basically no data in our redis instance and were encountering a cast exception upon trying to get suggestions. This performs a null check to prevent that exception from being thrown in the case of `{}` being passed in as the `redisResult`.