### PR TITLE
Update datatypes used in InfoResult to match datatypes used in RediSearch

### DIFF
--- a/RediSearchClient/GarbageCollectionStatistics.cs
+++ b/RediSearchClient/GarbageCollectionStatistics.cs
@@ -4,7 +4,7 @@ using static RediSearchClient.ConversionUtilities;
 namespace RediSearchClient
 {
     /// <summary>
-    /// Statistics... about garbarge collection. 
+    /// Statistics... about garbage collection. 
     /// </summary>
     public class GarbageCollectionStatistics
     {
@@ -32,26 +32,26 @@ namespace RediSearchClient
         /// Average GC cycle time: TotalMillisecondsRun / TotalCycles
         /// </summary>
         /// <value></value>
-        public int AverageCycleTimeMilliseconds { get; private set; }
+        public double AverageCycleTimeMilliseconds { get; private set; }
 
         /// <summary>
         /// In relation to the start time of the RediSearch/Redis process when was the 
         /// last time GC was run? (I think...)
         /// </summary>
         /// <value></value>
-        public int LastRunTimeMilliseconds { get; private set; }
+        public double LastRunTimeMilliseconds { get; private set; }
 
         /// <summary>
         /// TODO: Populate `GcNumericTreesMissed` summary.
         /// </summary>
         /// <value></value>
-        public int GcNumericTreesMissed { get; private set; }
+        public double GcNumericTreesMissed { get; private set; }
 
         /// <summary>
         /// TODO: Populate `GcBlocksDenied` summary.
         /// </summary>
         /// <value></value>
-        public int GcBlocksDenied { get; private set; }
+        public double GcBlocksDenied { get; private set; }
 
         internal static GarbageCollectionStatistics Create(RedisResult[] redisResult)
         {

--- a/RediSearchClient/InfoResult.cs
+++ b/RediSearchClient/InfoResult.cs
@@ -79,7 +79,7 @@ namespace RediSearchClient
         /// TODO: Populate `TotalInvertedIndexBlocks` summary.
         /// </summary>
         /// <value></value>
-        public int TotalInvertedIndexBlocks { get; private set; }
+        public long TotalInvertedIndexBlocks { get; private set; }
 
         /// <summary>
         /// TODO: Populate `OffsetVectorsSizeMegabytes` summary.
@@ -335,7 +335,7 @@ namespace RediSearchClient
                     return Array.Empty<object>();
                 }
 
-                if (results[0].Type ==  ResultType.MultiBulk)
+                if (results[0].Type == ResultType.MultiBulk)
                 {
                     return results.Select(ParseRedisResult);
                 }
@@ -352,7 +352,7 @@ namespace RediSearchClient
 
             var val = (RedisValue)redisResult;
 
-            return val.HasValue && val.TryParse(out double d) && !double.IsNaN(d) ? (object)d : (string) val;
+            return val.HasValue && val.TryParse(out double d) && !double.IsNaN(d) ? (object) d : (string) val;
         }
 
         private static string[] ParseIndexOptions(RedisResult[] redisResult)

--- a/RediSearchClient/RediSearchClient.csproj
+++ b/RediSearchClient/RediSearchClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net472;net461</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Authors>Tom Hanks (tombatron), Daniel Leach (leachdaniel), Ahmed Arnaout (asarnaout), Simon Turner (simonjturner), dave22000</Authors>
+    <Authors>Tom Hanks (tombatron), Daniel Leach (leachdaniel), Ahmed Arnaout (asarnaout), Simon Turner (simonjturner), dave22000, Gabe Willard (wss-jwillard)</Authors>
     <Company />
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <FileVersion>2.1.0.0</FileVersion>


### PR DESCRIPTION
Ran into the following exception that seems to be occasionally thrown from the RediSearchClient when the FT.INFO command is ran:

```
Catastrophic failure: System.AggregateException: One or more errors occurred. (Unable to cast from Double to long: '1.8446744073709552E+19')
 ---> System.InvalidCastException: Unable to cast from Double to long: '1.8446744073709552E+19'
   at StackExchange.Redis.RedisValue.op_Explicit(RedisValue value) in /_/src/StackExchange.Redis/RedisValue.cs:line 600
   at StackExchange.Redis.RedisResult.op_Explicit(RedisResult result) in /_/src/StackExchange.Redis/RedisResult.cs:line 152
   at RediSearchClient.InfoResult.Create(RedisResult[] redisResult)
   at RediSearchClient.DatabaseExtensions.GetInfoAsync(IDatabase db, String indexName)
```

Did a quick once over to check if all the datatypes on the `InfoResult` class matched the ones used in RediSearch itself, and found a handful that seem to be a mismatch.

`GarbageCollectionStatistics`:
https://github.com/RediSearch/RediSearch/blob/6171f8159ea8c5cdfbf69702c3dcd5f45af5652f/src/fork_gc.c#L1377

`InfoResult`:
https://github.com/RediSearch/RediSearch/blob/6171f8159ea8c5cdfbf69702c3dcd5f45af5652f/src/info_command.c#L222

Feedback is welcome!